### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/lib/nagios_check.rb
+++ b/lib/nagios_check.rb
@@ -67,7 +67,7 @@ module NagiosCheck
     def on(*args, &block)
       name = option_name(args.first)
       option_params = {
-        mandatory: args.delete(:mandatory) ? true : false
+        :mandatory => args.delete(:mandatory) ? true : false
       }
       if args.last.respond_to? :has_key? 
         option_params.merge! args.pop


### PR DESCRIPTION
Hello. There's a tiny bit of syntax in the gem that isn't compatible with Ruby 1.8 (new-style hash syntax).

Would you accept this patch so that I don't have to fork the gem?
