### PR TITLE
Modify the handling of @ symbol when specifying the check range

### DIFF
--- a/lib/nagios_check/range.rb
+++ b/lib/nagios_check/range.rb
@@ -9,7 +9,7 @@ module NagiosCheck
       unless tokens
         raise RuntimeError, "Pattern should be of form [@][~][min]:max" 
       end
-      @exclusive = true if tokens.include? "@"
+      @inverse = true if tokens.include? "@"
       case tokens[2]
       when nil, "" then @min = 0
       when '~' then @min = nil
@@ -19,8 +19,16 @@ module NagiosCheck
     end
 
     def include?(value)
-      if @exclusive
-        (@min.nil? || value > @min) && (@max.nil? || value < @max)
+      if @inverse
+        if @max.nil?
+          (@min.nil? || value < @min)
+        elsif @min.nil?
+          (@max.nil? || value > @max)
+        elsif @min == @max
+          false
+        else
+          (@min.nil? || value < @min) || (@max.nil? || value > @max)
+        end
       else
         (@min.nil? || value >= @min) && (@max.nil? || value <= @max)
       end

--- a/spec/range_spec.rb
+++ b/spec/range_spec.rb
@@ -36,12 +36,12 @@ describe NagiosCheck::Range do
   end
   
   context "when pattern is @:10" do
-    it { should_not contain -1 } 
-    it { should_not contain 0 } 
-    it { should     contain 5 } 
-    it { should_not contain 10 } 
-    it { should_not contain 10.0 } 
-    it { should_not contain 11 } 
+    it { should     contain -1 }
+    it { should_not contain 0 }
+    it { should_not contain 5 }
+    it { should_not contain 10 }
+    it { should_not contain 10.0 }
+    it { should     contain 11 }
   end
 
   context "when pattern is 10:" do
@@ -55,13 +55,13 @@ describe NagiosCheck::Range do
   end
   
   context "when pattern is @10:" do
-    it { should_not contain -1 } 
-    it { should_not contain 1 } 
-    it { should_not contain 9.9 } 
-    it { should_not contain 10 } 
-    it { should_not contain 10.0 } 
-    it { should     contain 10.1 } 
-    it { should     contain 11 } 
+    it { should     contain -1 }
+    it { should     contain 1 }
+    it { should     contain 9.9 }
+    it { should_not contain 10 }
+    it { should_not contain 10.0 }
+    it { should_not contain 10.1 }
+    it { should_not contain 11 }
   end
 
   context "when pattern is 10:11" do
@@ -77,28 +77,54 @@ describe NagiosCheck::Range do
     it { should_not contain 12 } 
   end
   
+  context "when pattern is 10:10" do
+    it { should_not contain -1 }
+    it { should_not contain 1 }
+    it { should_not contain 9.9 }
+    it { should     contain 10 }
+    it { should     contain 10.0 }
+    it { should_not contain 10.1 }
+    it { should_not contain 10.9 }
+    it { should_not contain 11 }
+    it { should_not contain 11.1 }
+    it { should_not contain 12 }
+  end
+
+  context "when pattern is @10:10" do
+    it { should_not contain -1 }
+    it { should_not contain 1 }
+    it { should_not contain 9.9 }
+    it { should_not contain 10 }
+    it { should_not contain 10.0 }
+    it { should_not contain 10.1 }
+    it { should_not contain 10.9 }
+    it { should_not contain 11 }
+    it { should_not contain 11.1 }
+    it { should_not contain 12 }
+  end
+
   context "when pattern is @10:11" do
-    it { should_not contain -1 } 
-    it { should_not contain 1 } 
-    it { should_not contain 9.9 } 
+    it { should     contain -1 }
+    it { should     contain 1 }
+    it { should     contain 9.9 }
     it { should_not contain 10 } 
     it { should_not contain 10.0 } 
-    it { should     contain 10.1 } 
+    it { should_not contain 10.1 }
     it { should_not contain 11 } 
-    it { should_not contain 11.1 } 
-    it { should_not contain 12 } 
+    it { should     contain 11.1 }
+    it { should     contain 12 }
   end
 
   context "when pattern is @10.05:11.05" do
-    it { should_not contain -1 } 
-    it { should_not contain 1 } 
-    it { should_not contain 9.9 } 
-    it { should_not contain 10 } 
-    it { should_not contain 10.0 } 
-    it { should     contain 10.1 } 
-    it { should     contain 11 } 
-    it { should_not contain 11.1 } 
-    it { should_not contain 12 } 
+    it { should     contain -1 }
+    it { should     contain 1 }
+    it { should     contain 9.9 }
+    it { should     contain 10 }
+    it { should     contain 10.0 }
+    it { should_not contain 10.1 }
+    it { should_not contain 11 }
+    it { should     contain 11.1 }
+    it { should     contain 12 }
   end
 
   context "when pattern is -1:1" do
@@ -120,11 +146,11 @@ describe NagiosCheck::Range do
   end
   
   context "when pattern is @~:1" do
-    it { should     contain -2 } 
-    it { should     contain -1 } 
-    it { should     contain 0 } 
+    it { should_not contain -2 }
+    it { should_not contain -1 }
+    it { should_not contain 0 }
     it { should_not contain 1 } 
-    it { should_not contain 2 } 
+    it { should     contain 2 }
   end
 
   context "when nil pattern" do 


### PR DESCRIPTION
It looks like the @ symbol does not behave as defined in http://nagiosplug.sourceforge.net/developer-guidelines.html#THRESHOLDFORMAT.  In the range code the @ symbol changed the range 10:20 from alerting on x < 10 or x > 20 to alerting on x <= 10 or x >= 20, when it should have change it to alerting on x >= 10 or x <= 20.

Because the spec is a bit difficult to understand, I generated this table.

<table>
  <tr>
    <th>Range</th>
    <th>Generate an alert if x</th>
  </tr>
  <tr>
    <td>10</td>
    <td>x &lt; 0 or x &gt; 10, (x does not alert if x &gt;= 0 or x &lt;= 10)</td>
  </tr>
  <tr>
    <td>@10</td>
    <td>x &gt;= 0 or x &lt;= 10, (x does not alert if x &lt; 0 or x &gt; 10)</td>
  </tr>
  <tr>
    <td>10:</td>
    <td>x &lt; 10, (x does not alert if x &gt;= 10)</td>
  </tr>
  <tr>
    <td>@10:</td>
    <td>x &gt;= 10, (x does not alert if x &lt; 10)</td>
  </tr>
  <tr>
    <td>~:10</td>
    <td>x &gt; 10, (x does not alert if x &lt;= 10)</td>
  </tr>
  <tr>
    <td>@~:10</td>
    <td>x &lt;= 10, (x does not alert if x &gt; 10)</td>
  </tr>
  <tr>
    <td>10:20</td>
    <td>x &lt; 10 or x &gt; 20, (x does not alert if x &gt;= 10 or x &lt;= 20)</td>
  </tr>
  <tr>
    <td>@10:20</td>
    <td>x &gt;= 10 and x &lt;= 20, (x does not alert if x &lt; 10 or x &gt; 20)</td>
  </tr>
</table>


So, with the above information, I changed the specs to match the above table.  Then I went and modified the range code to handle the change in the specs.
