### PR TITLE
Update rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.gem
 .bundle
-Gemfile.lock
 pkg/*
 *.swp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,19 @@ GEM
   specs:
     diff-lcs (1.2.5)
     rake (10.4.2)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
 
 PLATFORMS
   ruby
@@ -23,4 +28,4 @@ PLATFORMS
 DEPENDENCIES
   nagios_check!
   rake
-  rspec (~> 2.14.0)
+  rspec (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,26 @@
+PATH
+  remote: .
+  specs:
+    nagios_check (0.3.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    rake (10.4.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nagios_check!
+  rake
+  rspec (~> 2.14.0)

--- a/nagios_check.gemspec
+++ b/nagios_check.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", ">= 2.0.0"
+  s.add_development_dependency "rspec", "~> 2.14.0"
   s.add_development_dependency "rake"
 end

--- a/nagios_check.gemspec
+++ b/nagios_check.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", "~> 2.14.0"
+  s.add_development_dependency "rspec", "~> 3.2.0"
   s.add_development_dependency "rake"
 end

--- a/spec/finish_spec.rb
+++ b/spec/finish_spec.rb
@@ -1,8 +1,9 @@
+require 'pp' #DEBUG
 require 'spec_helper'
 def before_finish_test
-  before(:each) do
+  before(:each) do |example|
     subject.prepare
-    description = example.metadata[:example_group][:example_group][:description_args].first
+    description = example.metadata[:example_group][:parent_example_group][:description_args].first 
     if description.kind_of?(String) && /^when options are '(.*)'$/ =~ description
       subject.send :parse_options, $1.split
     end
@@ -34,19 +35,19 @@ describe OkTestCheck do
 
   context "when options are ''" do
     it "should fail when no value is given" do
-      lambda {
+      expect {
         subject.finish
-      }.should raise_error(RuntimeError, "No value was provided")
+      }.to raise_error(RuntimeError, "No value was provided")
     end
 
     context "when value is 0" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 5" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 10" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
   end
 end
@@ -56,19 +57,19 @@ describe WarningTestCheck do
 
   context "when options are '-w 10'" do
     context "when value is -1" do
-      specify { subject.finish.should == [1, "WARNING"] }
+      specify { expect(subject.finish).to eq([1, "WARNING"]) }
     end
     context "when value is 0" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 5" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 10" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 11" do
-      specify { subject.finish.should == [1, "WARNING"] }
+      specify { expect(subject.finish).to eq([1, "WARNING"]) }
     end
   end
 end
@@ -78,25 +79,25 @@ describe CriticalTestCheck do
 
   context "when options are '-w 10 -c 20'" do
     context "when value is -1" do
-      specify { subject.finish.should == [2, "CRITICAL"] }
+      specify { expect(subject.finish).to eq([2, "CRITICAL"]) }
     end
     context "when value is 0" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 5" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 10" do
-      specify { subject.finish.should == [0, "OK"] }
+      specify { expect(subject.finish).to eq([0, "OK"]) }
     end
     context "when value is 15" do
-      specify { subject.finish.should == [1, "WARNING"] }
+      specify { expect(subject.finish).to eq([1, "WARNING"]) }
     end
     context "when value is 20" do
-      specify { subject.finish.should == [1, "WARNING"] }
+      specify { expect(subject.finish).to eq([1, "WARNING"]) }
     end
     context "when value is 21" do
-      specify { subject.finish.should == [2, "CRITICAL"] }
+      specify { expect(subject.finish).to eq([2, "CRITICAL"]) }
     end
   end
 end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -21,14 +21,14 @@ describe NagiosCheck do
     specify { subject.send :parse_options, %w{-w 10} }
    
     it "fails if -w has no argument" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{-w} 
-      }.should raise_error(OptionParser::MissingArgument)
+      }.to raise_error(OptionParser::MissingArgument)
     end
     it "fails if -c is given" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{-c} 
-      }.should raise_error(OptionParser::InvalidOption)
+      }.to raise_error(OptionParser::InvalidOption)
     end
   end
   
@@ -44,15 +44,15 @@ describe NagiosCheck do
     specify { subject.send :parse_options, %w{-c 10} }
    
     it "fails if -c has no argument" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{-c} 
-      }.should raise_error(OptionParser::MissingArgument)
+      }.to raise_error(OptionParser::MissingArgument)
     end
    
     it "fails if -w is given" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{-w} 
-      }.should raise_error(OptionParser::InvalidOption)
+      }.to raise_error(OptionParser::InvalidOption)
     end
   end
   
@@ -69,24 +69,24 @@ describe NagiosCheck do
 
     it "works with '-a 10'" do
       subject.send :parse_options, %w{-a 10}
-      subject.options.a.should == "10"
+      expect(subject.options.a).to eq("10")
     end   
     
     it "works with '-b 20' and converts to int" do
       subject.send :parse_options, %w{-b 20}
-      subject.options.b.should == 20
+      expect(subject.options.b).to eq(20)
     end   
 
     it "fails if -a has no argument" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{-a} 
-      }.should raise_error(OptionParser::MissingArgument)
+      }.to raise_error(OptionParser::MissingArgument)
     end
    
     it "fails if -w is given" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{-w} 
-      }.should raise_error(OptionParser::InvalidOption)
+      }.to raise_error(OptionParser::InvalidOption)
     end
   end
   
@@ -99,14 +99,14 @@ describe NagiosCheck do
     end
 
     it "fails if -a is not given" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{} 
-      }.should raise_error(NagiosCheck::MissingOption)
+      }.to raise_error(NagiosCheck::MissingOption)
     end
 
     it "parses option a 3.14" do 
       subject.send :parse_options, %w{-a 3.14} 
-      subject.options.a.should == 3.14
+      expect(subject.options.a).to eq(3.14)
     end
   end
 
@@ -119,26 +119,26 @@ describe NagiosCheck do
     end
 
     it "fails if -a is not given" do
-      lambda {
+      expect {
         subject.send :parse_options, %w{} 
-      }.should raise_error(NagiosCheck::MissingOption)
+      }.to raise_error(NagiosCheck::MissingOption)
     end
 
     it "parses option a 3.14" do 
       subject.send :parse_options, %w{-a 3.14} 
-      subject.options.a.should == 3.14
+      expect(subject.options.a).to eq(3.14)
     end
   end
 
   shared_examples_for "default provided" do
     it "defaults to 3.14" do
       subject.send :parse_options, %w{} 
-      subject.options.a.should == 3.14 
+      expect(subject.options.a).to eq(3.14) 
     end
 
     it "parses option a at 1.4142" do 
       subject.send :parse_options, %w{-a 1.4142}
-      subject.options.a.should == 1.4142
+      expect(subject.options.a).to eq(1.4142)
     end
   end
 

--- a/spec/range_spec.rb
+++ b/spec/range_spec.rb
@@ -4,7 +4,7 @@ require 'pp'
 
 describe NagiosCheck::Range do
   subject { @range }
-  before(:each) do 
+  before(:each) do
     description = example.metadata[:example_group][:description_args].first 
     if /^when pattern is (.*)/ =~ description
       @range = NagiosCheck::Range::new($1)

--- a/spec/range_spec.rb
+++ b/spec/range_spec.rb
@@ -4,7 +4,7 @@ require 'pp'
 
 describe NagiosCheck::Range do
   subject { @range }
-  before(:each) do
+  before(:each) do |example|
     description = example.metadata[:example_group][:description_args].first 
     if /^when pattern is (.*)/ =~ description
       @range = NagiosCheck::Range::new($1)
@@ -12,156 +12,156 @@ describe NagiosCheck::Range do
   end
 
   context "when pattern is 10" do
-    it { should     alert_if -1 } 
-    it { should_not alert_if 0 } 
-    it { should_not alert_if 0.1 } 
-    it { should_not alert_if 1 } 
-    it { should_not alert_if 9 } 
-    it { should_not alert_if 9.9 } 
-    it { should_not alert_if 10 } 
-    it { should_not alert_if 10.0 } 
-    it { should     alert_if 10.1 } 
+    it { is_expected.to     alert_if -1 } 
+    it { is_expected.not_to alert_if 0 } 
+    it { is_expected.not_to alert_if 0.1 } 
+    it { is_expected.not_to alert_if 1 } 
+    it { is_expected.not_to alert_if 9 } 
+    it { is_expected.not_to alert_if 9.9 } 
+    it { is_expected.not_to alert_if 10 } 
+    it { is_expected.not_to alert_if 10.0 } 
+    it { is_expected.to     alert_if 10.1 } 
   end
 
   context "when pattern is :10" do
-    it { should     alert_if -1 } 
-    it { should_not alert_if 0 } 
-    it { should_not alert_if 0.1 } 
-    it { should_not alert_if 1 } 
-    it { should_not alert_if 9 } 
-    it { should_not alert_if 9.9 } 
-    it { should_not alert_if 10 } 
-    it { should_not alert_if 10.0 } 
-    it { should     alert_if 10.1 } 
+    it { is_expected.to     alert_if -1 } 
+    it { is_expected.not_to alert_if 0 } 
+    it { is_expected.not_to alert_if 0.1 } 
+    it { is_expected.not_to alert_if 1 } 
+    it { is_expected.not_to alert_if 9 } 
+    it { is_expected.not_to alert_if 9.9 } 
+    it { is_expected.not_to alert_if 10 } 
+    it { is_expected.not_to alert_if 10.0 } 
+    it { is_expected.to     alert_if 10.1 } 
   end
   
   context "when pattern is @:10" do
-    it { should_not alert_if -1 }
-    it { should     alert_if 0 }
-    it { should     alert_if 5 }
-    it { should     alert_if 10 }
-    it { should     alert_if 10.0 }
-    it { should_not alert_if 11 }
+    it { is_expected.not_to alert_if -1 }
+    it { is_expected.to     alert_if 0 }
+    it { is_expected.to     alert_if 5 }
+    it { is_expected.to     alert_if 10 }
+    it { is_expected.to     alert_if 10.0 }
+    it { is_expected.not_to alert_if 11 }
   end
 
   context "when pattern is 10:" do
-    it { should     alert_if -1 } 
-    it { should     alert_if 1 } 
-    it { should     alert_if 9.9 } 
-    it { should_not alert_if 10 } 
-    it { should_not alert_if 10.0 } 
-    it { should_not alert_if 10.1 } 
-    it { should_not alert_if 11 } 
+    it { is_expected.to     alert_if -1 } 
+    it { is_expected.to     alert_if 1 } 
+    it { is_expected.to     alert_if 9.9 } 
+    it { is_expected.not_to alert_if 10 } 
+    it { is_expected.not_to alert_if 10.0 } 
+    it { is_expected.not_to alert_if 10.1 } 
+    it { is_expected.not_to alert_if 11 } 
   end
   
   context "when pattern is @10:" do
-    it { should_not alert_if -1 }
-    it { should_not alert_if 1 }
-    it { should_not alert_if 9.9 }
-    it { should     alert_if 10 }
-    it { should     alert_if 10.0 }
-    it { should     alert_if 10.1 }
-    it { should     alert_if 11 }
+    it { is_expected.not_to alert_if -1 }
+    it { is_expected.not_to alert_if 1 }
+    it { is_expected.not_to alert_if 9.9 }
+    it { is_expected.to     alert_if 10 }
+    it { is_expected.to     alert_if 10.0 }
+    it { is_expected.to     alert_if 10.1 }
+    it { is_expected.to     alert_if 11 }
   end
 
   context "when pattern is 10:11" do
-    it { should     alert_if -1 } 
-    it { should     alert_if 1 } 
-    it { should     alert_if 9.9 } 
-    it { should_not alert_if 10 } 
-    it { should_not alert_if 10.0 } 
-    it { should_not alert_if 10.1 } 
-    it { should_not alert_if 10.9 } 
-    it { should_not alert_if 11 } 
-    it { should     alert_if 11.1 } 
-    it { should     alert_if 12 } 
+    it { is_expected.to     alert_if -1 } 
+    it { is_expected.to     alert_if 1 } 
+    it { is_expected.to     alert_if 9.9 } 
+    it { is_expected.not_to alert_if 10 } 
+    it { is_expected.not_to alert_if 10.0 } 
+    it { is_expected.not_to alert_if 10.1 } 
+    it { is_expected.not_to alert_if 10.9 } 
+    it { is_expected.not_to alert_if 11 } 
+    it { is_expected.to     alert_if 11.1 } 
+    it { is_expected.to     alert_if 12 } 
   end
   
   context "when pattern is 10:10" do
-    it { should     alert_if -1 }
-    it { should     alert_if 1 }
-    it { should     alert_if 9.9 }
-    it { should_not alert_if 10 }
-    it { should_not alert_if 10.0 }
-    it { should     alert_if 10.1 }
-    it { should     alert_if 10.9 }
-    it { should     alert_if 11 }
-    it { should     alert_if 11.1 }
-    it { should     alert_if 12 }
+    it { is_expected.to     alert_if -1 }
+    it { is_expected.to     alert_if 1 }
+    it { is_expected.to     alert_if 9.9 }
+    it { is_expected.not_to alert_if 10 }
+    it { is_expected.not_to alert_if 10.0 }
+    it { is_expected.to     alert_if 10.1 }
+    it { is_expected.to     alert_if 10.9 }
+    it { is_expected.to     alert_if 11 }
+    it { is_expected.to     alert_if 11.1 }
+    it { is_expected.to     alert_if 12 }
   end
 
   context "when pattern is @10:10" do
-    it { should_not alert_if -1 }
-    it { should_not alert_if 1 }
-    it { should_not alert_if 9.9 }
-    it { should     alert_if 10 }
-    it { should     alert_if 10.0 }
-    it { should_not alert_if 10.1 }
-    it { should_not alert_if 10.9 }
-    it { should_not alert_if 11 }
-    it { should_not alert_if 11.1 }
-    it { should_not alert_if 12 }
+    it { is_expected.not_to alert_if -1 }
+    it { is_expected.not_to alert_if 1 }
+    it { is_expected.not_to alert_if 9.9 }
+    it { is_expected.to     alert_if 10 }
+    it { is_expected.to     alert_if 10.0 }
+    it { is_expected.not_to alert_if 10.1 }
+    it { is_expected.not_to alert_if 10.9 }
+    it { is_expected.not_to alert_if 11 }
+    it { is_expected.not_to alert_if 11.1 }
+    it { is_expected.not_to alert_if 12 }
   end
 
   context "when pattern is @10:11" do
-    it { should_not alert_if -1 }
-    it { should_not alert_if 1 }
-    it { should_not alert_if 9.9 }
-    it { should     alert_if 10 } 
-    it { should     alert_if 10.0 } 
-    it { should     alert_if 10.1 }
-    it { should     alert_if 11 } 
-    it { should_not alert_if 11.1 }
-    it { should_not alert_if 12 }
+    it { is_expected.not_to alert_if -1 }
+    it { is_expected.not_to alert_if 1 }
+    it { is_expected.not_to alert_if 9.9 }
+    it { is_expected.to     alert_if 10 } 
+    it { is_expected.to     alert_if 10.0 } 
+    it { is_expected.to     alert_if 10.1 }
+    it { is_expected.to     alert_if 11 } 
+    it { is_expected.not_to alert_if 11.1 }
+    it { is_expected.not_to alert_if 12 }
   end
 
   context "when pattern is @10.05:11.05" do
-    it { should_not alert_if -1 }
-    it { should_not alert_if 1 }
-    it { should_not alert_if 9.9 }
-    it { should_not alert_if 10 }
-    it { should_not alert_if 10.0 }
-    it { should     alert_if 10.1 }
-    it { should     alert_if 11 }
-    it { should_not alert_if 11.1 }
-    it { should_not alert_if 12 }
+    it { is_expected.not_to alert_if -1 }
+    it { is_expected.not_to alert_if 1 }
+    it { is_expected.not_to alert_if 9.9 }
+    it { is_expected.not_to alert_if 10 }
+    it { is_expected.not_to alert_if 10.0 }
+    it { is_expected.to     alert_if 10.1 }
+    it { is_expected.to     alert_if 11 }
+    it { is_expected.not_to alert_if 11.1 }
+    it { is_expected.not_to alert_if 12 }
   end
 
   context "when pattern is -1:1" do
-    it { should     alert_if -2 } 
-    it { should_not alert_if -1 } 
-    it { should_not alert_if -0.9 } 
-    it { should_not alert_if 0 } 
-    it { should_not alert_if 0.9 } 
-    it { should_not alert_if 1 } 
-    it { should     alert_if 2 } 
+    it { is_expected.to     alert_if -2 } 
+    it { is_expected.not_to alert_if -1 } 
+    it { is_expected.not_to alert_if -0.9 } 
+    it { is_expected.not_to alert_if 0 } 
+    it { is_expected.not_to alert_if 0.9 } 
+    it { is_expected.not_to alert_if 1 } 
+    it { is_expected.to     alert_if 2 } 
   end
   
   context "when pattern is ~:1" do
-    it { should_not alert_if -2 } 
-    it { should_not alert_if -1 } 
-    it { should_not alert_if 0 } 
-    it { should_not alert_if 1 } 
-    it { should     alert_if 2 } 
+    it { is_expected.not_to alert_if -2 } 
+    it { is_expected.not_to alert_if -1 } 
+    it { is_expected.not_to alert_if 0 } 
+    it { is_expected.not_to alert_if 1 } 
+    it { is_expected.to     alert_if 2 } 
   end
   
   context "when pattern is @~:1" do
-    it { should     alert_if -2 }
-    it { should     alert_if -1 }
-    it { should     alert_if 0 }
-    it { should     alert_if 1 } 
-    it { should_not alert_if 2 }
+    it { is_expected.to     alert_if -2 }
+    it { is_expected.to     alert_if -1 }
+    it { is_expected.to     alert_if 0 }
+    it { is_expected.to     alert_if 1 } 
+    it { is_expected.not_to alert_if 2 }
   end
 
   context "when nil pattern" do 
     it "raises an error" do
-      lambda { NagiosCheck::Range.new nil }.should raise_error
+      expect { NagiosCheck::Range.new nil }.to raise_error
     end
   end
   
   context "when empty pattern" do 
     it "raises an error" do
-      lambda { NagiosCheck::Range.new "" }.should raise_error
+      expect { NagiosCheck::Range.new "" }.to raise_error
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ module Matchers
       "expected #{@actual} to alert for value #{@expected}" 
     end
 
-    def negative_failure_message
+    def failure_message_when_negated
       "expected #{@actual} not to alert for value #{@expected}"
     end
   end


### PR DESCRIPTION
This updates rspec to 3.2.

I used [transpec](http://yujinakayama.me/transpec/) to make the syntax changes to the specs.

I also took the liberty of adding Gemfile.lock to git.  I believe that the popular advice to not do so for a gem is flawed.  For example, after I cloned this project, I could not run the specs.  Here's why:
- The gemspec specified rspec ">= 2.0.0" (it probably should have been "~> 2.0.0")
- When I did "bundle install", it installed the latest rspec
- The latest rspec (3.2) was not compatible with the version 2 specs.

Had Gemfile.lock been checked in, I would have been assured of running the same version of rspec as the maintainer used.
