### PR TITLE
Support store_value "foo", nil to return [3, "UNKNOWN"]

### DIFF
--- a/lib/nagios_check.rb
+++ b/lib/nagios_check.rb
@@ -54,6 +54,7 @@ module NagiosCheck
   def finish
     raise "No value was provided" if @values.empty?
     value = @values.first.last
+    return [3, "UNKNOWN"] if value.nil?
     if @options.c && !@options.c.include?(value)
       return [2, "CRITICAL"]
     end
@@ -64,7 +65,7 @@ module NagiosCheck
   end
 
   def store_value(name, value, opts = {})
-    @values[name] = value.to_f
+    @values[name] = (value.nil? ? nil : value.to_f)
   end
 
   module ClassMethods

--- a/spec/finish_spec.rb
+++ b/spec/finish_spec.rb
@@ -48,6 +48,11 @@ describe OkTestCheck do
     context "when value is 10" do
       specify { subject.finish.should == [0, "OK"] }
     end
+
+    context "when nil is given" do
+      before { subject.store_value 'val', nil }
+      specify { subject.finish.should == [3, "UNKNOWN"] }
+    end
   end
 end
 


### PR DESCRIPTION
There are many scenarios where a check will need to answer "don't know"; perhaps its measured value is not stable/trustworthy or the given credentials have expired. Throwing an exception is currently the only way to achieve unknown, but that will produce an "internal error" message, which is misleading. This PR allows `store_value 'foo', nil` to signal that the plugin cannot ascertain a host/service status.

As an aside, this PR adds a nil check quirk in store_value to allow passing through nil. This is because .to_f will convert nil to "0.0". All tests pass if that .to_f is removed, and it is not clear to me that implicitly trying to convert the value to a float is a good idea. In fact, .to_f will convert any nonsense to "0.0", so if a sloppy check puts "12k" (or "NAN") into @values, it is probably better that the check errors than that it is implicitly converted to "0.0" and never fail. If you accept this PR, I will be happy to provide another PR that removes this behavior.