### PR TITLE
Add gem version badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 NagiosCheck
 ============
 
+[![Gem Version](https://badge.fury.io/rb/nagios_check.svg)](https://badge.fury.io/rb/nagios_check)
+
 Description
 -----------
 


### PR DESCRIPTION
Make it easier to see the current gem version in the readme. This is the default badge proposed by rubygems.org.