### PR TITLE
[WIP] Make it easier to write tests for checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,36 @@ end
 
 This check will execute `do_some_check` measure the time it takes to execute it and return both status and performance data labeled `duration`. 
 
+Writing Tests for Checks
+------------------------
+
+Checks can be integration tested by calling the `perform` method
+instead of the `run` method. `perform` takes an array of command line
+arguments and returns a `NagiosCheck::Result` object, which supports
+`ok?`, `warning?` and `critical?` methods to query the status and
+exposes the stored values:
+
+```ruby
+RSpec.describe SomeCheck do
+  it 'is ok by default' do
+    result = SomeCheck.new.perform(%w(-w 5 -c 10))
+
+    expect(result).to be_ok
+  end
+
+  it 'results in warning if there are more thn 5 uploads purchases' do
+    # Setup environment such that the check detects problems
+    # ...
+
+    result = SomeCheck.new.perform(%w(-w 5 -c 10))
+
+    expect(result).to be_warning
+    expect(result.values[:some_stored_value]).to eq(6)
+  end
+end
+
+```
+
 License
 -------
 Released under the MIT License.  See the [MIT-LICENSE][license] file for further details.


### PR DESCRIPTION
I found it a bit hard to write tests for my Nagios checks. Main issues that I encountered:

* No easy way to pass command line arguments to ensure command line options are defined correctly
* To do a real integration test, I have to invoke the `run` method, but `run` prints to `stdout` and calls `exit`
* Checks hold check results as inner state, which is not easy to access.  

So I started to refactor the code in a way that would make things easier. This commit presents a work in progress state. I just wanted to discuss my ideas before continuing.

The main changes are:

* Extract a `perform` method from the `run` method, which holds all the important logic but does not call `puts` or `exit`
* Allow passing a custom `argv` array into `perform`
* Return a new `NagiosCheck::Result` object, which holds all the state collected during the check. This object can then be queried in tests.

I included an example in the readme how checks can be tested now.

At the moment the `NagiosCheck` objects still hold a lot of result state that could be moved into the new `Result` objects. I think it would be an improvement to follow this route and turn `NagiosCheck` more or less into a Builder object for `Result` instances:

* Less methods in `NagiosCheck` mixin mean less risk of collision with methods defined in the class that uses the mixin.
* Clearer separation of check logic and result formatting logic

If you agree with this general direction, I'd be happy to work an a complete PR.