### PR TITLE
Travis compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ NagiosCheck
 ============
 
 [![Gem Version](https://badge.fury.io/rb/nagios_check.svg)](https://badge.fury.io/rb/nagios_check)
+[![Build Status](https://travis-ci.org/dbroeglin/nagios_check.svg?branch=master)](https://travis-ci.org/dbroeglin/nagios_check)
 
 Description
 -----------

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,5 @@ require 'bundler/gem_tasks'
 
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:rspec)
+
+task :default => :rspec

--- a/nagios_check.gemspec
+++ b/nagios_check.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 2.14.0"
-  s.add_development_dependency "rake"
+  s.add_development_dependency "rake", "< 11.0"
 end


### PR DESCRIPTION
Let's enable Travis for this repository. Tests are passing on Travis [for my fork](https://travis-ci.org/tf/nagios_check). All I had to do was restrict the Rake version, since RSpec 2 does not play nice with Rake >= 11 and define a default Rake task.